### PR TITLE
base frame timestamp off epicsTS

### DIFF
--- a/perkinElmerApp/src/PerkinElmer.cpp
+++ b/perkinElmerApp/src/PerkinElmer.cpp
@@ -810,7 +810,6 @@ void PerkinElmer::endFrameCallback(HACQDESC hAcqDesc)
   int           acquiring;
   NDArray       *pImage;
   NDDataType_t  dataType;
-  epicsTimeStamp currentTime;
   static const char *functionName = "endFrameCallback";
     
   asynPrint(pasynUserSelf, ASYN_TRACE_FLOW,
@@ -937,9 +936,8 @@ void PerkinElmer::endFrameCallback(HACQDESC hAcqDesc)
   arrayCounter++;
   setIntegerParam(NDArrayCounter, arrayCounter);
   pImage->uniqueId = arrayCounter;
-  epicsTimeGetCurrent(&currentTime);
-  pImage->timeStamp = currentTime.secPastEpoch + currentTime.nsec / 1.e9;
   updateTimeStamp(&pImage->epicsTS);
+  pImage->timeStamp = pImage->epicsTS.secPastEpoch + pImage->epicsTS.nsec / 1.e9;
 
   /* Get any attributes that have been defined for this driver */
   getAttributes(pImage->pAttributeList);


### PR DESCRIPTION
Part of a series of PRs for AreaDetector repos that sets the outgoing frames' timeStamp member to be equal to the frame's epicsTS member, updated with updateTimeStamp, when not retreiving a timestamp from hardware.